### PR TITLE
Add experimental AGI CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,3 +536,15 @@ browser. To try it out, run:
 ```bash
 python scripts/run_cua.py
 ```
+
+## AGI CLI (Experimental)
+
+This repository now provides a simple command-line interface for chatting with an OpenAI model. It is meant for experimentation and does **not** provide actual AGI capabilities.
+
+Run the CLI with:
+
+```bash
+python -m autogpt.agi_cli
+```
+
+Set the `OPENAI_API_KEY` environment variable to enable responses from OpenAI. Without an API key the CLI will notify you that it is not configured.

--- a/autogpt/agi_cli.py
+++ b/autogpt/agi_cli.py
@@ -1,0 +1,44 @@
+import os
+import openai
+
+
+def respond_to_prompt(prompt: str, model: str = "gpt-3.5-turbo") -> str:
+    """Send a prompt to OpenAI's ChatCompletion API and return the response.
+
+    If the ``OPENAI_API_KEY`` environment variable is not set, a message is
+    returned instead of attempting a network call.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return "OpenAI API key not configured."
+
+    openai.api_key = api_key
+    response = openai.ChatCompletion.create(
+        model=model, messages=[{"role": "user", "content": prompt}]
+    )
+    return response["choices"][0]["message"]["content"].strip()
+
+
+def run_interactive(model: str = "gpt-3.5-turbo") -> None:
+    """Start an interactive chat session."""
+    print("Starting AGI CLI (experimental). Type 'exit' to quit.")
+    while True:
+        try:
+            user_input = input("> ")
+        except (EOFError, KeyboardInterrupt):
+            break
+        if user_input.strip().lower() in {"exit", "quit"}:
+            break
+        reply = respond_to_prompt(user_input, model=model)
+        print(reply)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Simple CLI interface using OpenAI's Chat API."
+    )
+    parser.add_argument("--model", default="gpt-3.5-turbo", help="OpenAI model name")
+    args = parser.parse_args()
+    run_interactive(args.model)

--- a/tests/test_agi_cli.py
+++ b/tests/test_agi_cli.py
@@ -1,0 +1,14 @@
+from autogpt.agi_cli import respond_to_prompt
+
+def test_respond_to_prompt_no_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert "API key" in respond_to_prompt("Hello")
+
+
+def test_respond_to_prompt_with_mock(monkeypatch):
+    def mock_create(model, messages):
+        return {"choices": [{"message": {"content": "Hi"}}]}
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr("openai.ChatCompletion.create", mock_create)
+    assert respond_to_prompt("Hello") == "Hi"


### PR DESCRIPTION
## Summary
- add `autogpt/agi_cli.py` with a minimal interactive CLI using OpenAI's chat API
- provide unit tests for the CLI
- document the new CLI in the README

## Testing
- `pytest tests/test_agi_cli.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'ddg' from 'duckduckgo_search')*

------
https://chatgpt.com/codex/tasks/task_e_68462e9f0a9c832d82e5a28351964862