### PR TITLE
Add documentation generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Development of this free, open-source project is made possible by all the <a hre
 - 🧠 GPT-4 instances for text generation
 - 🔗 Access to popular websites and platforms
 - 🗃️ File storage and summarization with GPT-3.5
+- 📄 Automatic generation of documentation from code snippets
 
 ## 📋 Requirements
 

--- a/autogpt/app.py
+++ b/autogpt/app.py
@@ -6,6 +6,7 @@ from autogpt.commands.evaluate_code import evaluate_code
 from autogpt.commands.google_search import google_official_search, google_search
 from autogpt.commands.improve_code import improve_code
 from autogpt.commands.write_tests import write_tests
+from autogpt.commands.generate_docs import generate_docs
 from autogpt.config import Config
 from autogpt.commands.image_gen import generate_image
 from autogpt.commands.audio_text import read_audio_from_file
@@ -177,6 +178,8 @@ def execute_command(command_name: str, arguments):
             return improve_code(arguments["suggestions"], arguments["code"])
         elif command_name == "write_tests":
             return write_tests(arguments["code"], arguments.get("focus"))
+        elif command_name == "generate_docs":
+            return generate_docs(arguments["code"], arguments.get("focus"))
         elif command_name == "execute_python_file":  # Add this command
             return execute_python_file(arguments["file"])
         elif command_name == "execute_shell":

--- a/autogpt/commands/generate_docs.py
+++ b/autogpt/commands/generate_docs.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+
+from autogpt.llm_utils import call_ai_function
+
+
+def generate_docs(code: str, focus: list[str] | None = None) -> str:
+    """Generate documentation for the provided code."""
+
+    function_string = (
+        "def generate_documentation(code: str, focus: Optional[List[str]] = None) -> str:"
+    )
+    args = [code, json.dumps(focus) if focus is not None else "None"]
+    description_string = (
+        "Generates documentation for the provided code, focusing on specified areas if required."
+    )
+
+    return call_ai_function(function_string, args, description_string)

--- a/autogpt/prompt.py
+++ b/autogpt/prompt.py
@@ -80,6 +80,11 @@ def get_prompt() -> str:
             "write_tests",
             {"code": "<full_code_string>", "focus": "<list_of_focus_areas>"},
         ),
+        (
+            "Generate Documentation",
+            "generate_docs",
+            {"code": "<full_code_string>", "focus": "<list_of_focus_areas>"},
+        ),
         ("Execute Python File", "execute_python_file", {"file": "<file>"}),
         ("Generate Image", "generate_image", {"prompt": "<prompt>"}),
         ("Send Tweet", "send_tweet", {"text": "<text>"}),

--- a/tests/test_generate_docs.py
+++ b/tests/test_generate_docs.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import patch
+
+import tests.context
+from autogpt.commands.generate_docs import generate_docs
+
+
+class TestGenerateDocs(unittest.TestCase):
+    @patch("autogpt.commands.generate_docs.call_ai_function")
+    def test_generate_docs_calls_ai_function(self, mock_call):
+        mock_call.return_value = "Docstring"
+        result = generate_docs("print('hello')", focus=["usage"])
+        self.assertEqual(result, "Docstring")
+        function_string = (
+            "def generate_documentation(code: str, focus: Optional[List[str]] = None) -> str:"
+        )
+        mock_call.assert_called_once_with(
+            function_string,
+            ["print('hello')", "[\"usage\"]"],
+            "Generates documentation for the provided code, focusing on specified areas if required.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `generate_docs` command to produce docs from code
- expose new command in prompt
- handle new command in app
- document the feature in README
- test command behavior

## Testing
- `flake8 autogpt/ tests/ --select E303,W293,W291,W292,E305,E231,E302`
- `python -m unittest discover tests` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_684636eea824832db3fdfeaa0f6be8c8